### PR TITLE
Add support for queries without login

### DIFF
--- a/src/perplexity_cli/api/endpoints.py
+++ b/src/perplexity_cli/api/endpoints.py
@@ -15,11 +15,12 @@ from .models import Answer, QueryParams, QueryRequest, SSEMessage, WebResult
 class PerplexityAPI:
     """High-level interface to Perplexity API."""
 
-    def __init__(self, token: str, timeout: int = 60) -> None:
+    def __init__(self, token: str | None = None, timeout: int = 60) -> None:
         """Initialise Perplexity API client.
 
         Args:
-            token: Authentication JWT token.
+            token: Optional authentication JWT token. If not provided, requests
+                are made anonymously.
             timeout: Request timeout in seconds.
         """
         self.client = SSEClient(token=token, timeout=timeout)

--- a/src/perplexity_cli/cli.py
+++ b/src/perplexity_cli/cli.py
@@ -379,11 +379,11 @@ def _stream_query_response(
         status = e.response.status_code
         logger.error(f"HTTP error {status} during streaming: {e}")
         click.echo()  # Newline after streamed content
-        if status == 401:
+        if status == 401 and api.client.token:
             click.echo("✗ Authentication failed. Token may be expired.", err=True)
             click.echo("\nRe-authenticate with: perplexity-cli auth", err=True)
             sys.exit(1)
-        elif status == 403:
+        elif status == 403 and api.client.token:
             click.echo("✗ Access forbidden. Check your permissions.", err=True)
             sys.exit(1)
         elif status == 429:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -181,16 +181,16 @@ class TestCLICommands:
 
     @patch("perplexity_cli.cli.TokenManager")
     def test_query_not_authenticated(self, mock_tm_class, runner):
-        """Test query when not authenticated."""
+        """Test query without authentication attempts anonymous query."""
         mock_tm = Mock()
         mock_tm.load_token.return_value = None
         mock_tm_class.return_value = mock_tm
 
         result = runner.invoke(query, ["test query"])
 
-        assert result.exit_code == 1
-        assert "Not authenticated" in result.output
-        assert "perplexity-cli auth" in result.output
+        # Without token, query is attempted anonymously (may succeed or fail)
+        # Should not show "Not authenticated" error anymore
+        assert "Not authenticated" not in result.output
 
     @patch("perplexity_cli.cli.StyleManager")
     @patch("perplexity_cli.cli.TokenManager")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -370,12 +370,13 @@ wheels = [
 
 [[package]]
 name = "perplexity-cli"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },
     { name = "httpx" },
+    { name = "python-dateutil" },
     { name = "rich" },
     { name = "tenacity" },
     { name = "websockets" },
@@ -401,6 +402,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.0" },
+    { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
     { name = "tenacity", specifier = ">=8.0" },
@@ -491,6 +493,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -527,6 +541,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/1a/a49f071f04c42345c793d22f6cf5e0920095e286119ee53a64a3a3004825/ruff-0.14.4-py3-none-win32.whl", hash = "sha256:643b69cb63cd996f1fc7229da726d07ac307eae442dd8974dbc7cf22c1e18fff", size = 12493429, upload-time = "2025-11-06T22:07:38.43Z" },
     { url = "https://files.pythonhosted.org/packages/bc/22/e58c43e641145a2b670328fb98bc384e20679b5774258b1e540207580266/ruff-0.14.4-py3-none-win_amd64.whl", hash = "sha256:26673da283b96fe35fa0c939bf8411abec47111644aa9f7cfbd3c573fb125d2c", size = 13635380, upload-time = "2025-11-06T22:07:40.496Z" },
     { url = "https://files.pythonhosted.org/packages/30/bd/4168a751ddbbf43e86544b4de8b5c3b7be8d7167a2a5cb977d274e04f0a1/ruff-0.14.4-py3-none-win_arm64.whl", hash = "sha256:dd09c292479596b0e6fec8cd95c65c3a6dc68e9ad17b8f2382130f87ff6a75bb", size = 12663065, upload-time = "2025-11-06T22:07:42.603Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
First of all, I'm a regular Perplexity Pro user and I love this tool, it's fantastic for using perplexity.ai from the terminal without having to go through the API, which will deduct from your API credit despite having unlimited queries (soft rate limit) using the apps and web interface.

One thing came to mind though: you can use perplexity.ai without logging in, why can't you do that using `perplexity-cli`? After a quick investigation, I found out that, if you set the correct `Origin` and `Referer` headers and set `x-request-id` to a uuid, like the frontend does, you can send unauthorised queries just fine.

So, I had Kimi K2.5 implement most of the code for me, did a thorough code review and testing and now logging in is optional for queries using this PR. :)

During testing, I also noticed that the cli tests fail due to a version update, but I'll just file an issue for that. It might also make sense to consider running `ruff` over the codebase again, since a few files I changed would have resulted in unrelated formatting changes if I formatted the whole files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request headers and authentication/error-handling for core query traffic; could alter API behavior or trigger stricter upstream checks, but the surface area is limited to query/client paths.
> 
> **Overview**
> Enables **anonymous querying**: `SSEClient`/`PerplexityAPI` now accept an optional token and only send `Authorization` when present, allowing `perplexity-cli query` to run without forcing `auth`.
> 
> To support unauthenticated requests, the HTTP client adds browser-like headers (`Origin`, `Referer`, `x-request-id`) and adjusts retry/error handling so 401/403 are treated as non-retryable only for authenticated calls. CLI messaging/tests are updated to stop failing fast when no token is found.
> 
> Lockfile updates bump `perplexity-cli` to `0.3.0` and add `python-dateutil` (with `six`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f158e5b84fd0528b3ff917131e872e8543b9f0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->